### PR TITLE
pypi2port: Add python 3.7 and remove 3.6

### DIFF
--- a/pypi2port/pypi2port.py
+++ b/pypi2port/pypi2port.py
@@ -595,7 +595,7 @@ def create_portfile(dict, file_name, dict2):
 			file.write('python.versions     27 {0}\n\n'.format(
 					   dict['requires_python']))
 		else:
-			file.write('python.versions     27 36\n\n')
+			file.write('python.versions     27 37\n\n')
 
 		print("Finding dependencies...")
 		file.write('if {${name} ne ${subport}} {\n')


### PR DESCRIPTION
Should we switch to 37 only or do we still need 36 among the default python versions?

One more thing: this file uses a super weird mixture of tabs and spaces. Should we switch to spaces only or are there other preferences?