### PR TITLE
Portindex2json: Make the license field consistent with "port info" command

### DIFF
--- a/portindex2json/portindex2json.tcl
+++ b/portindex2json/portindex2json.tcl
@@ -18,7 +18,12 @@ package require json::write
 proc tcl2json_list {tcl_list} {
     set new_tcl_list {}
     foreach element $tcl_list {
-        lappend new_tcl_list [::json::write string $element]
+        if {[llength $element] > 1} {
+            # the element is itself a list, recursively calling tcl2json_list
+            lappend new_tcl_list [tcl2json_list $element]
+        } else {
+            lappend new_tcl_list [::json::write string $element]
+        }
     }
     return [::json::write array {*}$new_tcl_list]
 }
@@ -142,7 +147,7 @@ while {[gets $fd line] >= 0} {
     array set portinfo $line
     array unset json_portinfo
     foreach key [array names portinfo] {
-        if {$key eq "categories" || $key eq "variants" || [string match "depends_*" $key]} {
+        if {$key in [list categories variants license] || [string match "depends_*" $key]} {
             set json_portinfo($key) [tcl2json_list $portinfo($key)]
         } elseif {$key eq "maintainers"} {
             set json_portinfo($key) [parse_maintainers $portinfo($key)]


### PR DESCRIPTION
Closes: https://github.com/macports/macports-webapp/issues/44