### PR TITLE
Add some additional debugging statements to restore_ports.tcl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/.DS_Store
+*.swp

--- a/restore_ports/restore_ports.tcl
+++ b/restore_ports/restore_ports.tcl
@@ -134,7 +134,9 @@ proc sort_ports {portList} {
             ui_debug "newList length is now [llength $newList]"
         }
         if {[llength $newList] == $oldLen} {
-            ui_error "we appear to be stuck (newList is same length as old one: $oldLen); exiting..."
+            ui_debug "we appear to be stuck (newList is same length as old one: $oldLen)"
+            ui_error "All remaining ports have unsatisfied dependencies (circular dependency?):"
+            ui_error $newList
             return -code error "infinite loop"
         }
     }


### PR DESCRIPTION
I have been having some trouble using `restore_ports.tcl` to reinstall all my ports after migration, and so I added some additional debugging statements to the script to help me find out what has been going wrong. I'm leaving the added `-d` flag undocumented from the help output, as I doubt it would be useful to casual users. 
(edit: note that despite the additional debugging output, it hasn't actually helped me to solve the problem I've been experiencing. I can attach the script output and my `myports.txt` if that would help show what's going on)