### PR TITLE
cpan2port: minor style improvement

### DIFF
--- a/cpan2port/cpan2port
+++ b/cpan2port/cpan2port
@@ -260,7 +260,7 @@ sub portfile {
              }
          }
          if ($depends_build.$depends_lib ne '') {
-             $depends = "\nif {\${perl5.major} != \"\"} {\n" . $depends_build . $depends_lib . "}\n";
+             $depends = qq[\nif {\${perl5.major} ne ""} {\n] . $depends_build . $depends_lib . "}\n";
          }
     }
 


### PR DESCRIPTION
Use `ne` instead of `!=` for non-numeric exact string comparison
Use alternative delimiter `qq[]` to avoid escaping `""` in string