### PR TITLE
Working on port message

### DIFF
--- a/restore_ports/restore_ports.tcl
+++ b/restore_ports/restore_ports.tcl
@@ -153,6 +153,7 @@ proc install_ports {operationList} {
     foreach op $operationList {
         set name [string trim [lindex $op 0]]
         set variations [lindex $op 1]
+        ui_msg "Working on port: $name $variations..."
         set active [lindex $op 2]
 
         if {!$active} {


### PR DESCRIPTION
Add a message to the output as the restore_ports script starts to install each port. The message is "Working on port:", followed by port name, followed by variant tags if any. This message is nicely set off from the other output, which is prefixed by `--->`. Thus if a port or its dependency fails to install, it is clearer which underlying port request started the chain which led to the error.

The output now looks like this:
Working on port: p5.28-web-scraper ...
--->  Computing dependencies for p5.28-web-scraper
--->  Fetching archive for p5.28-web-scraper
...
--->  Cleaning p5.28-web-scraper
Working on port: pango x11 + quartz +...
--->  Computing dependencies for pango
--->  Fetching archive for pango
...